### PR TITLE
Added GD support for libjpeg and optimized RUN command into one line.

### DIFF
--- a/Dockerfile.php5
+++ b/Dockerfile.php5
@@ -1,13 +1,15 @@
 FROM php:5.6-fpm-alpine
 
-RUN apk --update add bash libpng-dev libjpeg libvpx-dev
-
-# Install required PHP modules
-RUN docker-php-ext-install \
-	mysql \
-	mysqli \
-	gd \
-	curl
+# Configure and install required PHP modules
+RUN apk --update add bash libpng-dev libjpeg-turbo-dev libvpx-dev \
+	&& docker-php-ext-configure gd \
+		--with-gd \
+		--with-jpeg-dir=/usr/include/ \
+	&& docker-php-ext-install \
+		mysql \
+		mysqli \
+		gd \
+		curl
 
 ADD https://raw.githubusercontent.com/php/php-src/PHP-5.6/php.ini-production /usr/local/etc/php/php.ini
 COPY php-entrypoint.sh /


### PR DESCRIPTION
With previous image this was the output from php -i showed this GD section:

GD Support => enabled
GD Version => bundled (2.1.0 compatible)
GIF Read Support => enabled
GIF Create Support => enabled
PNG Support => enabled
libPNG Version => 1.6.21
WBMP Support => enabled
XBM Support => enabled

The new image shows this:

GD Support => enabled
GD Version => bundled (2.1.0 compatible)
GIF Read Support => enabled
GIF Create Support => enabled
JPEG Support => enabled
libJPEG Version => 8
PNG Support => enabled
libPNG Version => 1.6.21
WBMP Support => enabled
XBM Support => enabled